### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/src/main/java/net/openhft/smoothie/BytecodeGen.java
+++ b/src/main/java/net/openhft/smoothie/BytecodeGen.java
@@ -61,6 +61,18 @@ final class BytecodeGen {
     private static final CustomClassLoadingOption CUSTOM_CLASS_LOADING =
             parseCustomClassLoadingOption();
 
+    static final ClassLoader SMOOTHIE_CLASS_LOADER = canonicalize(BytecodeGen.class.getClassLoader());
+
+    /** ie. "net.openhft.smoothie" */
+    static final String SMOOTHIE_PACKAGE =
+            BytecodeGen.class.getName().replaceFirst("\\.smoothie\\..*$", ".smoothie");
+
+    /**
+     * Weak cache of bridge class loaders that make the Smoothie Map implementation
+     * classes visible to various code-generated proxies of client classes.
+     */
+    private static final WeakHashMap<ClassLoader, WeakReference<ClassLoader>> CLASS_LOADER_CACHE = new WeakHashMap<>();
+
     /**
      * The options for Smoothie custom class loading.
      */
@@ -106,24 +118,11 @@ final class BytecodeGen {
             return defaultValue;
         }
     }
-
-    static final ClassLoader SMOOTHIE_CLASS_LOADER = canonicalize(BytecodeGen.class.getClassLoader());
-
     // initialization-on-demand...
     private static class SystemBridgeHolder {
         static final BridgeClassLoader SYSTEM_BRIDGE = new BridgeClassLoader();
+
     }
-
-    /** ie. "net.openhft.smoothie" */
-    static final String SMOOTHIE_PACKAGE =
-            BytecodeGen.class.getName().replaceFirst("\\.smoothie\\..*$", ".smoothie");
-
-    /**
-     * Weak cache of bridge class loaders that make the Smoothie Map implementation
-     * classes visible to various code-generated proxies of client classes.
-     */
-    private static final WeakHashMap<ClassLoader, WeakReference<ClassLoader>> CLASS_LOADER_CACHE =
-            new WeakHashMap<>();
 
     private static ClassLoader getFromClassLoaderCache(ClassLoader typeClassLoader) {
         synchronized (CLASS_LOADER_CACHE) {

--- a/src/main/java/net/openhft/smoothie/Segment.java
+++ b/src/main/java/net/openhft/smoothie/Segment.java
@@ -55,6 +55,10 @@ class Segment<K, V> extends SegmentPrimitiveArea implements Cloneable {
     @SuppressWarnings("unused")
     Object k0, v0;
 
+    static final long HASH_TABLE_OFFSET;
+    static final long ALLOC_OFFSET;
+    static final int ALLOC_INDEX_SHIFT = (ARRAY_OBJECT_INDEX_SCALE == 4 ? 2 : 3) + 1;
+
     static final int STORED_HASH_BITS = 10;
     static final int ALLOC_INDEX_BITS = 6;
     static final int HASH_TABLE_SLOT_SIZE = 2; // in bytes
@@ -611,10 +615,6 @@ class Segment<K, V> extends SegmentPrimitiveArea implements Cloneable {
         }
         return modCount;
     }
-
-    static final long HASH_TABLE_OFFSET;
-    static final long ALLOC_OFFSET;
-    static final int ALLOC_INDEX_SHIFT = (ARRAY_OBJECT_INDEX_SCALE == 4 ? 2 : 3) + 1;
 
     private static long allocOffset(long allocIndex) {
         return ALLOC_OFFSET + (allocIndex << ALLOC_INDEX_SHIFT);

--- a/src/main/java/net/openhft/smoothie/SegmentClassGenerator.java
+++ b/src/main/java/net/openhft/smoothie/SegmentClassGenerator.java
@@ -29,6 +29,8 @@ final class SegmentClassGenerator {
     private static final AtomicReferenceArray<Class<Segment>> classCache =
             new AtomicReferenceArray<>(SmoothieMap.MAX_ALLOC_CAPACITY + 1);
 
+    private SegmentClassGenerator() {}
+
     @SuppressWarnings("unchecked")
     public static <T extends Segment> Class<T> acquireClass(int allocationCapacity) {
         Class c;
@@ -80,8 +82,5 @@ final class SegmentClassGenerator {
         cw.visitEnd();
 
         return cw.toByteArray();
-    }
-
-    private SegmentClassGenerator() {
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava… appear in a pre-defined order